### PR TITLE
chore: bump minimum go version to 1.25.0

### DIFF
--- a/modules/collectorschema/build/go.mod
+++ b/modules/collectorschema/build/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/open-telemetry/opentelemetry-collector-releases/contrib
 
-go 1.25.1
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.150.0

--- a/modules/collectorschema/go.mod
+++ b/modules/collectorschema/go.mod
@@ -1,6 +1,6 @@
 module github.com/pavolloffay/opentelemetry-mcp-server/modules/collectorschema
 
-go 1.25.1
+go 1.25.0
 
 require (
 	github.com/philippgille/chromem-go v0.7.0


### PR DESCRIPTION
This is to allow its import in the collector which currently still sets the minimum go version to the oldest version of N-1 releases of go.